### PR TITLE
Upgrade to OCaml 5 (Piaf 0.2.0 with Eio)

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -24,6 +24,6 @@
   reason
   dune
   (cmdliner(>= 1.2.0))
-  (piaf (>= 0.1.0))
+  (piaf (>= 0.2.0))
   (fmt (>= 0.9.0)))
  (tags ("advent-of-code")))

--- a/lib/dune
+++ b/lib/dune
@@ -7,7 +7,7 @@
  (name import)
  (wrapped false)
  (modules import let fn)
- (libraries fmt lwt))
+ (libraries fmt eio_main))
 
 (library
  (name problem)

--- a/lib/let.ml
+++ b/lib/let.ml
@@ -1,4 +1,2 @@
 let (let@) = Result.bind
-let (let+) = Lwt.bind
-let (let*) = Lwt_result.bind
 let (let-) = Option.bind

--- a/lib/problem_runner.ml
+++ b/lib/problem_runner.ml
@@ -48,8 +48,10 @@ module Run_mode = struct
           Error "Cannot fetch input from adventofcode.com: missing credentials."
       | Some credentials ->
           Result.map_error Piaf.Error.to_string
-          @@ Lwt_main.run
-          @@
+          @@ Eio_main.run
+          @@ fun env ->
+          Eio.Switch.run
+          @@ fun sw ->
           let uri =
             Uri.of_string
             @@ String.concat "/"
@@ -62,10 +64,10 @@ module Run_mode = struct
                  ]
           in
           let headers = Credentials.to_headers credentials in
-          let* response = Piaf.Client.Oneshot.get ~headers uri in
-          let* body = Piaf.Body.to_string response.body in
+          let@ response = Piaf.Client.Oneshot.get ~sw env ~headers uri in
+          let@ body = Piaf.Body.to_string response.body in
           write_file filename body;
-          Lwt_result.return body
+          Result.ok body
 
   let get_input (year : int) (day : int) : t -> (string, string) result =
     function
@@ -79,8 +81,10 @@ module Run_mode = struct
     | Test_from_puzzle_input _ -> Ok None
     | Submit { credentials } ->
         Result.map_error Piaf.Error.to_string
-        @@ Lwt_main.run
-        @@
+        @@ Eio_main.run
+        @@ fun env ->
+        Eio.Switch.run
+        @@ fun sw ->
         let uri =
           Uri.of_string
           @@ String.concat "/"
@@ -99,9 +103,9 @@ module Run_mode = struct
         let body =
           Piaf.Body.of_string @@ Fmt.(str "level=%d&answer=%s" part output)
         in
-        let* response = Piaf.Client.Oneshot.post ~headers ~body uri in
-        let* body = Piaf.Body.to_string response.body in
-        Lwt_result.return (Some body)
+        let@ response = Piaf.Client.Oneshot.post ~sw env ~headers ~body uri in
+        let@ body = Piaf.Body.to_string response.body in
+        Result.ok (Some body)
 end
 
 module Options = struct

--- a/tanenbaum.opam
+++ b/tanenbaum.opam
@@ -14,7 +14,7 @@ depends: [
   "reason"
   "dune" {>= "3.7"}
   "cmdliner" {>= "1.2.0"}
-  "piaf" {>= "0.1.0"}
+  "piaf" {>= "0.2.0"}
   "fmt" {>= "0.9.0"}
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
Piaf 0.1.0 doesn't support OCaml 5: https://discuss.ocaml.org/t/simple-modern-http-client-library/11239/15.

To make this project work with OCaml 5, I upgraded Piaf to 0.2.0, converting the existing Lwt code to Eio, using the following references:

- https://discuss.ocaml.org/t/ann-eio-1-0-first-major-release/14334
- https://github.com/ocaml-multicore/icfp-2023-eio-tutorial/blob/main/doc/porting.md
- https://github.com/anmonteiro/piaf

I tested these changes against https://adventofcode.com/2024/day/1 and the following actions appear to be working:

- [x] Downloading the input file
- [x] Submitting the answer
